### PR TITLE
Fix some spelling error

### DIFF
--- a/dtd/ofc.dtd
+++ b/dtd/ofc.dtd
@@ -232,7 +232,7 @@
 <!--  Payment Inquiry Transaction: Sent to request information
 	regarding a payment from a user's account to a payee. 
 	A successful PAYMTRQ/PAYMTRS transaction set must have 
-	previously occured in a prior session before a payment
+	previously occurred in a prior session before a payment
 	request is possible. The SRVRTID for that payment must be 
 	known to inquire on a payment.
 -->

--- a/lib/messages.cpp
+++ b/lib/messages.cpp
@@ -49,7 +49,7 @@ void show_line_number()
   if (ofx_show_position == true)
   {
     SGMLApplication::Location *location = new SGMLApplication::Location(entity_ptr, position);
-    cerr << "(Above message occured on Line " << location->lineNumber << ", Column " << location->columnNumber << ")" << endl;
+    cerr << "(Above message occurred on Line " << location->lineNumber << ", Column " << location->columnNumber << ")" << endl;
     delete location;
   }
 }

--- a/lib/ofc_sgml.cpp
+++ b/lib/ofc_sgml.cpp
@@ -91,7 +91,7 @@ public:
       is_data_element = false;
       break;
     default:
-      message_out(ERROR, "Unknow SGML content type?!?!?!? OpenSP interface changed?");
+      message_out(ERROR, "Unknown SGML content type?!?!?!? OpenSP interface changed?");
     }
 
     if (is_data_element == false)
@@ -198,7 +198,7 @@ public:
       /* There is a bug in OpenSP 1.3.4, which won't send endElement Event for some elements, and will instead send an error like "document type does not allow element "MESSAGE" here".  Incoming_data should be empty in such a case, but it will not be if the endElement event was skiped. So we empty it, so at least the last element has a chance of having valid data */
       if (incoming_data != "")
       {
-        message_out (ERROR, "startElement: incoming_data should be empty! You are probably using OpenSP <= 1.3.4.  The folowing data was lost: " + incoming_data );
+        message_out (ERROR, "startElement: incoming_data should be empty! You are probably using OpenSP <= 1.3.4.  The following data was lost: " + incoming_data );
         incoming_data.assign ("");
       }
     }
@@ -290,7 +290,7 @@ public:
 
   /** \brief Callback: SGML parse error
    *
-   An OpenSP callback, get's called when a parser error has occured.
+   An OpenSP callback, get's called when a parser error has occurred.
   */
   void error (const ErrorEvent & event)
   {

--- a/lib/ofx_containers_misc.cpp
+++ b/lib/ofx_containers_misc.cpp
@@ -159,7 +159,7 @@ OfxBalanceContainer::~OfxBalanceContainer()
   }
   else
   {
-    message_out (ERROR, "I completed a " + type + " element, but I havent found a suitable parent to save it");
+    message_out (ERROR, "I completed a " + type + " element, but I haven't found a suitable parent to save it");
   }
 }
 void OfxBalanceContainer::add_attribute(const string identifier, const string value)

--- a/lib/ofx_sgml.cpp
+++ b/lib/ofx_sgml.cpp
@@ -97,7 +97,7 @@ public:
       is_data_element = false;
       break;
     default:
-      message_out(ERROR, "Unknow SGML content type?!?!?!? OpenSP interface changed?");
+      message_out(ERROR, "Unknown SGML content type?!?!?!? OpenSP interface changed?");
     }
 
     if (is_data_element == false)
@@ -204,7 +204,7 @@ public:
       /* There is a bug in OpenSP 1.3.4, which won't send endElement Event for some elements, and will instead send an error like "document type does not allow element "MESSAGE" here".  Incoming_data should be empty in such a case, but it will not be if the endElement event was skiped. So we empty it, so at least the last element has a chance of having valid data */
       if (incoming_data != "")
       {
-        message_out (ERROR, "startElement: incoming_data should be empty! You are probably using OpenSP <= 1.3.4.  The folowing data was lost: " + incoming_data );
+        message_out (ERROR, "startElement: incoming_data should be empty! You are probably using OpenSP <= 1.3.4.  The following data was lost: " + incoming_data );
         incoming_data.assign ("");
       }
     }
@@ -309,7 +309,7 @@ public:
 
   /** \brief Callback: SGML parse error
    *
-   An OpenSP callback, get's called when a parser error has occured.
+   An OpenSP callback, get's called when a parser error has occurred.
   */
   void error (const ErrorEvent & event)
   {

--- a/ofxdump/cmdline.ggo
+++ b/ofxdump/cmdline.ggo
@@ -16,7 +16,7 @@ option	"list-import-formats"	-	"List available import file formats 'import-forma
 
 #section "Debug output options"
 option	"msg_parser"	-	"Output file parsing messages"	flag	off
-option	"msg_debug"	-	"Output messages meant for debuging"	flag	off
+option	"msg_debug"	-	"Output messages meant for debugging"	flag	off
 option	"msg_warning"	-	"Output warning messages about abnormal conditions and unknown constructs"	flag	on
 option	"msg_error"	-	"Output error messages"	flag	on
 option	"msg_info"	-	"Output informational messages about the progress of the library"	flag	on

--- a/ofxdump/ofxdump.cpp
+++ b/ofxdump/ofxdump.cpp
@@ -12,7 +12,7 @@
  stderr.  To know exactly what the library understands about of a particular
  ofx response file, just call ofxdump on that file.
  *
- * ofxdump is meant as both a C++ code example and a developper/debuging
+ * ofxdump is meant as both a C++ code example and a developper/debugging
  tool.  It uses every function and every structure of the LibOFX API.  By
  default, WARNING, INFO, ERROR and STATUS messages are enabled.  You can
  change these defaults at the top of ofxdump.cpp
@@ -398,7 +398,7 @@ int ofx_proc_status_cb(struct OfxStatusData data, void * status_data)
   cout << "ofx_proc_status():\n";
   if (data.ofx_element_name_valid == true)
   {
-    cout << "    Ofx entity this status is relevent to: " << data.ofx_element_name << " \n";
+    cout << "    Ofx entity this status is relevant to: " << data.ofx_element_name << " \n";
   }
   if (data.severity_valid == true)
   {


### PR DESCRIPTION
These errors were detected by lintian during the Debian packaging.

https://anonscm.debian.org/git/pkg-gnucash/libofx.git/tree/debian/patches/Fix_spelling_error.patch