### PR TITLE
Use glibtoolize on macOS

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,7 +4,7 @@
 echo "Running mkdir -p config"
 mkdir -p config
 echo "Running libtoolize --force"
-libtoolize --force
+libtoolize --force || glibtoolize --force
 echo "Running aclocal"
 aclocal -I ./m4
 echo "Running autoheader"


### PR DESCRIPTION
On macOS brew(1) install libtoolize as glibtoolize. So if libtoolize
does exist we try to use glibtoolize instead.