### PR TITLE
Fix compiler warning: not a prototype

### DIFF
--- a/inc/libofx.h.in
+++ b/inc/libofx.h.in
@@ -107,7 +107,7 @@ extern "C" {
    *
    @return the new context, to be used by the other functions.
   */
-  LibofxContextPtr libofx_get_new_context();
+  LibofxContextPtr libofx_get_new_context(void);
 
   /**
    * \brief Free all ressources used by this context.


### PR DESCRIPTION
Fix the compiler warning:
../inc/libofx.h:110:42: warning: this function declaration is not a prototype
      [-Wstrict-prototypes]
  LibofxContextPtr libofx_get_new_context();
                                         ^
                                          void