### PR TITLE
Use glibtoolize os macOS

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,12 @@
 set -e
 echo "Running mkdir -p config"
 mkdir -p config
-${LIBTOOLIZE=libtoolize} #Allow overriding for homebrew which uses glibtoolize
+if command -v glibtoolize
+then
+	LIBTOOLIZE=glibtoolize
+else
+	LIBTOOLIZE=libtoolize
+fi
 echo "Running ${LIBTOOLIZE} --force"
 ${LIBTOOLIZE} --force
 echo "Running aclocal"


### PR DESCRIPTION
On macOS brew(1) install libtoolize as glibtoolize.

Homebrew does _not_ define ``LIBTOOLIZE``. So the previous change will not solve the problem.
Running ``./autogen.sh`` will still fail on macOS (without manual intervention).
```
$ ./autogen.sh 
Running mkdir -p config
./autogen.sh: line 6: libtoolize: command not found
```