### PR TITLE
A couple of changes originating from gnucash user experiences

### DIFF
--- a/lib/ofx_preproc.cpp
+++ b/lib/ofx_preproc.cpp
@@ -160,10 +160,8 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
             // Is the next character really the newline?
             if (input_file.peek() == '\n')
             {
-                // Yes. Then discard that newline character from the stream and
-                // append it manually to the output string.
+                // Yes. Then discard that newline character from the stream
                 input_file.get();
-                s_buffer.append("\n");
             }
         }
 
@@ -297,6 +295,8 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
              * this isn't a great loss for now.
              */
             s_buffer = sanitize_proprietary_tags(s_buffer);
+            if (s_buffer.empty())
+                continue;
           }
           //cout<< s_buffer<<"\n";
           if (file_is_xml == false)
@@ -326,7 +326,7 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
 #endif
           }
           //cout << s_buffer << "\n";
-          tmp_file.write(s_buffer.c_str(), s_buffer.length());
+          tmp_file << s_buffer << endl;
         }
 
         if (ofx_start == true &&

--- a/lib/ofx_preproc.cpp
+++ b/lib/ofx_preproc.cpp
@@ -34,13 +34,13 @@
 #include <iconv.h>
 #endif
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
 # define DIRSEP "\\"
 #else
 # define DIRSEP "/"
 #endif
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
 # include "win32.hh"
 # include <windows.h> // for GetModuleFileName()
 # undef ERROR
@@ -110,7 +110,11 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
     mkTempFileName("libofxtmpXXXXXX", tmp_filename, sizeof(tmp_filename));
 
     message_out(DEBUG, "ofx_proc_file(): Creating temp file: " + string(tmp_filename));
+#ifdef __WIN32__
+    tmp_file_fd = mkstemp_win32(tmp_filename);
+#else
     tmp_file_fd = mkstemp(tmp_filename);
+#endif
     if (tmp_file_fd)
     {
       tmp_file.open(tmp_filename);
@@ -309,7 +313,7 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
             size_t outbytesleft = inbytesleft * 2 - 1;
             char * iconv_buffer = (char*) malloc (inbytesleft * 2);
             memset(iconv_buffer, 0, inbytesleft * 2);
-#if defined(OS_WIN32) || defined(__sun) || defined(__NetBSD__)
+#if defined(__sun) || defined(__NetBSD__)
             const char * inchar = (const char *)s_buffer.c_str();
 #else
             char * inchar = (char *)s_buffer.c_str();
@@ -536,7 +540,7 @@ string sanitize_proprietary_tags(string input_string)
 }
 
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
 static std::string get_dtd_installation_directory()
 {
   // Partial implementation of
@@ -591,7 +595,7 @@ std::string find_dtd(LibofxContextPtr ctx, const std::string& dtd_filename)
     }
   }
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
   dtd_path_filename = get_dtd_installation_directory();
   if (!dtd_path_filename.empty())
   {

--- a/lib/ofx_preproc.cpp
+++ b/lib/ofx_preproc.cpp
@@ -474,7 +474,8 @@ string sanitize_proprietary_tags(string input_string)
   while (!tag_name.empty())
   {
     // Determine whether the current tag is proprietary.
-    if (tag_name.find('.') != string::npos)
+    if ((tag_name.find('.') != string::npos) ||   // tag has a . in the name
+       (tag_name == "CATEGORY"))                  // Chase bank started setting these in 2017
     {
         find_tag_close (input_string, tag_name, find_pos);
         size_t tag_size = find_pos - last_known_good_pos;

--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -28,7 +28,7 @@
 #include "messages.hh"
 #include "ofx_utilities.hh"
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
 # define DIRSEP "\\"
 #else
 # define DIRSEP "/"
@@ -298,7 +298,7 @@ std::string get_tmp_dir()
   if (var) return var;
   var = getenv("TEMP");
   if (var) return var;
-#ifdef OS_WIN32
+#ifdef __WIN32__
   return "C:\\";
 #else
   return "/tmp";

--- a/lib/win32.cpp
+++ b/lib/win32.cpp
@@ -25,9 +25,9 @@
 
 
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
 
-int mkstemp(char *tmpl)
+int mkstemp_win32(char *tmpl)
 {
   int fd = -1;
   int len;

--- a/lib/win32.hh
+++ b/lib/win32.hh
@@ -21,9 +21,9 @@
 #endif
 
 
-#ifdef OS_WIN32
+#ifdef __WIN32__
 
-int mkstemp(char *tmpl);
+int mkstemp_win32(char *tmpl);
 
 
 #endif


### PR DESCRIPTION
The PR proposes the following:

1. changes to get libofx working properly on Windows (built in a mingw-w64 environment, 32-bit). This one fixes [gnucash bug 793461](https://bugzilla.gnome.org/show_bug.cgi?id=793461)
1. a couple of improvements in preparsing and sanitizing an ofx file, slightly prefering a more c++ style
1. drop the proprietary "CATEGORY" tag while sanitizing. This one fixes [gnucash bug 771451](https://bugzilla.gnome.org/show_bug.cgi?id=771451). It's not the full implementation of any of @jralls' suggestions in issue #1 but it does fix the immediate problem.