### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: cpp
 
+
+arch:
+ - amd64
+ - ppc64le
+
 dist: bionic
 
 sudo: required


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/libofx/builds/199574880

Please have a look.

Regards,
Manish