### PR TITLE
Respect standard autotools variables for libdir, docdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,8 +6,6 @@ endif
 DIST_SUBDIRS = m4 inc dtd lib doc . ofx2qif ofxdump ofxconnect
 SUBDIRS = m4 inc dtd lib doc . ofx2qif ofxdump $(MAYBE_OFXCONNECT)
 
-docdir = $(datadir)/doc/libofx
-
 doc_DATA = \
   AUTHORS \
   COPYING \

--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,7 @@ AC_ARG_WITH(opensp-libs,
 [  --with-opensp-libs=PATH         specify where to look for libosp
                                   - default is /usr/lib],
 			OPENSPLIBPATH="$with_opensp_libs",
-			OPENSPLIBPATH="/usr/lib")
+			OPENSPLIBPATH="${libdir}")
 
 			echo $OPENSPLIBPATH
 for d in /usr/include/OpenSP /usr/local/include/OpenSP /usr/include/sp/generic /usr/local/include/sp/generic; do

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,7 +1,5 @@
 SUBDIRS =
 
-docdir = ${prefix}/share/doc/libofx
-
 EXTRA_DIST = \
 	doxygen.cfg \
 	ofx_sample_files \


### PR DESCRIPTION
Two changes:

1. Modify configure.ac to respect --libdir when locating OpenSP. This fixes builds on "multilib" systems where /usr/lib and /usr/lib64 may be used for distinct purposes. This should have no effect if unset (defaults to /usr/lib).

2. Drop local override of 'docdir' to allow --docdir to be set and respected at build time. This should have no effect if unset (defaults to /usr/share/doc/libofx).

These are essentially just changes to allow flexibility and don't aim to deviate from the current default behaviour.