### PR TITLE
Improve imported date stability

### DIFF
--- a/lib/ofx_utilities.hh
+++ b/lib/ofx_utilities.hh
@@ -64,7 +64,7 @@ string CharStringtostring(const SGMLApplication::CharString source, string &dest
 string AppendCharStringtostring(const SGMLApplication::CharString source, string &dest);
 
 ///Convert a C++ string containing a time in OFX format to a C time_t
-time_t ofxdate_to_time_t(const string ofxdate);
+time_t ofxdate_to_time_t(const string& ofxdate);
 
 ///Convert OFX amount of money to double float
 double ofxamount_to_double(const string ofxamount);


### PR DESCRIPTION
See GnuCash [Bug 797848](https://bugs.gnucash.org/show_bug.cgi?id=797848) and [Bug ](https://bugs.gnucash.org/show_bug.cgi?id=636340)

This PR has two commits. The first one implements the changes discussed with @benoitg in the first bug; the second is a general cleanup of `ofxdate_to_time_t` that's easier to read and might even be a bit faster. If you don't like the second by all means just cherry-pick the first.