### PR TITLE
Fix Win32 Build Failure

### DIFF
--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -30,6 +30,8 @@
 
 #ifdef __WIN32__
 # define DIRSEP "\\"
+/* MSWin calls it _mkgmtime instead of timegm */
+# define timegm(tm) _mkgmtime(tm)
 #else
 # define DIRSEP "/"
 #endif


### PR DESCRIPTION
I neglected to test the previous PR on Windows, which has [`_mkgmtime{struct tm*)`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/mkgmtime-mkgmtime32-mkgmtime64?view=msvc-160) instead of `timegm(struct tm*)`.

