### PR TITLE
Reverse the application of gmt offset seconds to struct tm::tm_sec.

### DIFF
--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -152,7 +152,7 @@ string AppendCharStringtostring(const SGMLApplication::CharString source, string
     float ofx_gmt_offset = atof(offset_str.c_str());
     std::time_t temptime = std::time(nullptr);
     static const double secs_per_hour = 3600.0;
-    time.tm_sec += static_cast<int>(ofx_gmt_offset * secs_per_hour);
+    time.tm_sec -= static_cast<int>(ofx_gmt_offset * secs_per_hour);
     return timegm(&time);
   }
 


### PR DESCRIPTION
A positive gmt offset means that UTC is that many seconds before the
time indicated in struct tm so the gmt offset should be subtracted
from tm_sec not added.

Fixes https://bugs.gnucash.org/show_bug.cgi?id=798267.