### PR TITLE
MSVC fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,19 @@
 ACLOCAL_AMFLAGS = -I m4
 
+if BUILD_OFX2QIF
+  MAYBE_OFX2QIF = ofx2qif
+endif
+
+if BUILD_OFXDUMP
+  MAYBE_OFXDUMP = ofxdump
+endif
+
 if BUILD_OFXCONNECT
   MAYBE_OFXCONNECT = ofxconnect
 endif
+
 DIST_SUBDIRS = m4 inc dtd lib doc . ofx2qif ofxdump ofxconnect
-SUBDIRS = m4 inc dtd lib doc . ofx2qif ofxdump $(MAYBE_OFXCONNECT)
+SUBDIRS = m4 inc dtd lib doc . $(MAYBE_OFX2QIF) $(MAYBE_OFXDUMP) $(MAYBE_OFXCONNECT)
 
 doc_DATA = \
   AUTHORS \

--- a/configure.ac
+++ b/configure.ac
@@ -330,13 +330,35 @@ PKG_CHECK_MODULES(LIBXMLPP,libxml++-2.6 >= 2.6,
 #	[AC_DEFINE(HAVE_QT, 1, [Defined if Qt Gui is available])],
 #        [AC_MSG_WARN([Qt is not available. Some experimental direct connect samples will not be fully functional.])])
 
+# check if building tools
+# ----------------------------------------------------------------------------
+
+AC_ARG_ENABLE(tools,
+        AS_HELP_STRING(--disable-tools,[Disable building of CLI tools: ofx2qif, ofxdump, ofxconnect] (no)),
+[case "${enableval}" in
+  yes) tools=yes ;;
+  no)  tools=no ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --disable-tools]) ;;
+esac],[tools=yes])
+
+build_ofx2qif=no
+build_ofxdump=no
 build_ofxconnect=no
-if test "$libcurl_available" = yes; then
-	if test "$have_libxmlpp" = yes; then
-		build_ofxconnect=yes
+
+if test x$tools = xyes ; then
+	build_ofx2qif=yes
+	build_ofxdump=yes
+
+	if test "$libcurl_available" = yes; then
+		if test "$have_libxmlpp" = yes; then
+			build_ofxconnect=yes
+		fi
 	fi
 fi
-AM_CONDITIONAL([BUILD_OFXCONNECT], [test "$build_ofxconnect" = yes])
+
+AM_CONDITIONAL([BUILD_OFX2QIF], [test "x$build_ofx2qif" = xyes])
+AM_CONDITIONAL([BUILD_OFXDUMP], [test x"$build_ofxdump" = xyes])
+AM_CONDITIONAL([BUILD_OFXCONNECT], [test "x$build_ofxconnect" = xyes])
 
 # check for iconv
 # ----------------------------------------------------------------------------

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -45,8 +45,8 @@ AM_CPPFLAGS = \
 	-I${OPENSPINCLUDES} \
 	-DMAKEFILE_DTD_PATH=\"${LIBOFX_DTD_DIR}\"
 
-#libofx_la_LIBADD = @LIBOBJS@ ${OPENSPLIBS} -lstdc++
-libofx_la_LIBADD = $(OPENSPLIBS) $(ICONV_LIBS) -lstdc++
+#libofx_la_LIBADD = @LIBOBJS@ ${OPENSPLIBS}
+libofx_la_LIBADD = $(OPENSPLIBS) $(ICONV_LIBS)
 libofx_la_LDFLAGS = -no-undefined -version-info @LIBOFX_SO_CURRENT@:@LIBOFX_SO_REVISION@:@LIBOFX_SO_AGE@
 
 

--- a/lib/ofx_preproc.cpp
+++ b/lib/ofx_preproc.cpp
@@ -35,13 +35,13 @@
 #include <iconv.h>
 #endif
 
-#ifdef __WIN32__
+#ifdef _WIN32
 # define DIRSEP "\\"
 #else
 # define DIRSEP "/"
 #endif
 
-#ifdef __WIN32__
+#ifdef _WIN32
 # include "win32.hh"
 # include <windows.h> // for GetModuleFileName()
 # undef ERROR
@@ -107,7 +107,7 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
     mkTempFileName("libofxtmpXXXXXX", tmp_filename, sizeof(tmp_filename));
 
     message_out(DEBUG, "ofx_proc_file(): Creating temp file: " + std::string(tmp_filename));
-#ifdef __WIN32__
+#ifdef _WIN32
     tmp_file_fd = mkstemp_win32(tmp_filename);
 #else
     tmp_file_fd = mkstemp(tmp_filename);
@@ -510,7 +510,7 @@ std::string sanitize_proprietary_tags(std::string input_string)
 }
 
 
-#ifdef __WIN32__
+#ifdef _WIN32
 static std::string get_dtd_installation_directory()
 {
   // Partial implementation of
@@ -565,7 +565,7 @@ std::string find_dtd(LibofxContextPtr ctx, const std::string& dtd_filename)
     }
   }
 
-#ifdef __WIN32__
+#ifdef _WIN32
   dtd_path_filename = get_dtd_installation_directory();
   if (!dtd_path_filename.empty())
   {

--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -28,7 +28,7 @@
 #include "messages.hh"
 #include "ofx_utilities.hh"
 
-#ifdef __WIN32__
+#ifdef _WIN32
 # define DIRSEP "\\"
 /* MSWin calls it _mkgmtime instead of timegm */
 # define timegm(tm) _mkgmtime(tm)
@@ -234,7 +234,7 @@ std::string get_tmp_dir()
   if (var) return var;
   var = getenv("TEMP");
   if (var) return var;
-#ifdef __WIN32__
+#ifdef _WIN32
   return "C:\\";
 #else
   return "/tmp";

--- a/lib/win32.cpp
+++ b/lib/win32.cpp
@@ -18,14 +18,24 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#endif
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
 
 
 
-#ifdef __WIN32__
+#ifdef _WIN32
+
+#ifdef _MSC_VER
+#include <Windows.h>
+#include <io.h>
+#define strcasecmp strcmpi
+#define snprintf _snprintf
+#define open _open
+#endif
 
 int mkstemp_win32(char *tmpl)
 {

--- a/lib/win32.hh
+++ b/lib/win32.hh
@@ -21,7 +21,7 @@
 #endif
 
 
-#ifdef __WIN32__
+#ifdef _WIN32
 
 int mkstemp_win32(char *tmpl);
 

--- a/ofx2qif/Makefile.am
+++ b/ofx2qif/Makefile.am
@@ -1,5 +1,5 @@
 bin_PROGRAMS = ofx2qif
-ofx2qif_LDADD = $(top_builddir)/lib/libofx.la
+ofx2qif_LDADD = $(top_builddir)/lib/libofx.la -lstdc++
 ofx2qif_SOURCES = ofx2qif.c
 AM_CPPFLAGS = \
 	-I${top_builddir}/inc


### PR DESCRIPTION
This is a bunch of fixes that allow to compile against MSVC, with an exception of the `getopt` that likely needs a more thorough discussion.

Originally provided by:
https://invent.kde.org/packaging/craft-blueprints-kde/-/tree/master/libs/libofx

References #46 