### PR TITLE
Fix .pc to support static build

### DIFF
--- a/libofx.pc.in
+++ b/libofx.pc.in
@@ -10,7 +10,7 @@ Description: libofx is a library for processing Open Financial eXchange (OFX) da
 Version: @VERSION@
 Requires:
 Conflicts:
-#Libs: -L${libdir} @OPENSPLIBS@ -lofx
-#Cflags: -I${includedir} -I@OPENSPINCLUDES@ 
 Libs: -L${libdir} -lofx
+Libs.private: @OPENSPLIBS@
 Cflags: -I${includedir}
+Cflags.private: -I@OPENSPINCLUDES@


### PR DESCRIPTION
OpenSP libs and includes need to be explicitly declared in
Libs.private and Cflags.private for static OFX build to be
consumable.