### PR TITLE
Fix some memory leaks

### DIFF
--- a/lib/ofx_sgml.cpp
+++ b/lib/ofx_sgml.cpp
@@ -443,8 +443,8 @@ int ofx_proc_sgml(LibofxContext * libofx_context, int argc, char * const* argv)
   parserKit.setOption (ParserEventGeneratorKit::showOpenEntities);
   EventGenerator *egp =	parserKit.makeEventGenerator (argc, argv);
   egp->inhibitMessages (true);	/* Error output is handled by libofx not OpenSP */
-  OFXApplication *app = new OFXApplication(libofx_context);
-  unsigned nErrors = egp->run (*app); /* Begin parsing */
+  OFXApplication app(libofx_context);
+  unsigned nErrors = egp->run (app); /* Begin parsing */
   delete egp;  //Note that this is where bug is triggered
   return nErrors > 0;
 }

--- a/ofxdump/ofxdump.cpp
+++ b/ofxdump/ofxdump.cpp
@@ -1145,6 +1145,7 @@ int ofx_proc_status_cb(struct OfxStatusData data, void * status_data)
 
 int main (int argc, char *argv[])
 {
+  int rc = 0;
   gengetopt_args_info args_info;
 
   /* let's call our cmdline parser */
@@ -1201,12 +1202,15 @@ int main (int argc, char *argv[])
         cout << "file: " << args_info.inputs[i] << endl ;
       }
     }
-    return libofx_proc_file(libofx_context, args_info.inputs[0], file_format);
+    int rc = libofx_proc_file(libofx_context, args_info.inputs[0], file_format);
   }
   else
   {
     if ( !skiphelp )
       cmdline_parser_print_help();
   }
-  return 0;
+
+  libofx_free_context(libofx_context);
+  cmdline_parser_free(&args_info);
+  return rc;
 }

--- a/ofxdump/ofxdump.cpp
+++ b/ofxdump/ofxdump.cpp
@@ -1202,7 +1202,7 @@ int main (int argc, char *argv[])
         cout << "file: " << args_info.inputs[i] << endl ;
       }
     }
-    int rc = libofx_proc_file(libofx_context, args_info.inputs[0], file_format);
+    rc = libofx_proc_file(libofx_context, args_info.inputs[0], file_format);
   }
   else
   {


### PR DESCRIPTION
When compiled with -fsanitize=address, running ofxdump produces 3 warnings about memory leaks. None of them seem likely to  result in excessive memory consumption as each allocation is only executed once during the program. This change is mainly just to clean up the output when running a version that uses the address sanitizer.