### PR TITLE
Build once

### DIFF
--- a/ofxconnect/Makefile.am
+++ b/ofxconnect/Makefile.am
@@ -26,4 +26,8 @@ EXTRA_DIST = cmdline.ggo test-privateserver.sh
 TESTS = test-privateserver.sh 
 
 ofxconnect.1: ofxconnect$(EXEEXT) $(top_srcdir)/configure.ac
-	help2man -n 'Create a statement request file' -N --output=ofxconnect.1 ./ofxconnect$(EXEEXT)
+if HAVE_HELP2MAN
+	$(HELP2MAN)  -n 'Create a statement request file' -N --output=ofxconnect.1 ./ofxconnect$(EXEEXT)
+else
+	echo "*** No man page available because of missing help2man tool" > $@
+endif

--- a/ofxconnect/Makefile.am
+++ b/ofxconnect/Makefile.am
@@ -25,6 +25,5 @@ EXTRA_DIST = cmdline.ggo test-privateserver.sh
 # the key needed to run this test.
 TESTS = test-privateserver.sh 
 
-ofxconnect.1: ofxconnect.cpp $(top_srcdir)/configure.ac
-	$(MAKE) $(AM_MAKEFLAGS) ofxconnect$(EXEEXT)
+ofxconnect.1: ofxconnect$(EXEEXT) $(top_srcdir)/configure.ac
 	help2man -n 'Create a statement request file' -N --output=ofxconnect.1 ./ofxconnect$(EXEEXT)

--- a/ofxdump/Makefile.am
+++ b/ofxdump/Makefile.am
@@ -15,8 +15,7 @@ cmdline.c cmdline.h: cmdline.ggo Makefile
 
 endif
 
-ofxdump.1: ofxdump.cpp $(top_srcdir)/configure.ac
-	$(MAKE) $(AM_MAKEFLAGS) ofxdump$(EXEEXT)
+ofxdump.1: ofxdump$(EXEEXT) $(top_srcdir)/configure.ac
 if HAVE_HELP2MAN
 	$(HELP2MAN) -n 'Dump content of OFX files as human-readable text' -N --output=ofxdump.1 ./ofxdump$(EXEEXT)
 else


### PR DESCRIPTION
Parallel builds can fail because the man-page build makes the executable instead of depending on it. E.g.:
```
Making all in ofxdump
make[2]: Entering directory '/c/gcdev64/gnucash/master/build/libofx-0.10.2/ofxdump'
gcc -DHAVE_CONFIG_H -I. -I/c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump -I..  -I../inc '-DCMDLINE_PARSER_PACKAGE="ofxdump"' -I/c/gcdev64/msys2/mingw32/include -I/usr/include  -DIN_LIBOFX -g -O2 -MT cmdline.o -MD -MP -MF .deps/cmdline.Tpo -c -o cmdline.o /c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump/cmdline.c
g++ -DHAVE_CONFIG_H -I. -I/c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump -I..  -I../inc '-DCMDLINE_PARSER_PACKAGE="ofxdump"' -I/c/gcdev64/msys2/mingw32/include -I/usr/include  -DIN_LIBOFX -g -O2 -MT ofxdump.o -MD -MP -MF .deps/ofxdump.Tpo -c -o ofxdump.o /c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump/ofxdump.cpp
make  ofxdump.exe
make[3]: Entering directory '/c/gcdev64/gnucash/master/build/libofx-0.10.2/ofxdump'
gcc -DHAVE_CONFIG_H -I. -I/c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump -I..  -I../inc '-DCMDLINE_PARSER_PACKAGE="ofxdump"' -I/c/gcdev64/msys2/mingw32/include -I/usr/include  -DIN_LIBOFX -g -O2 -MT cmdline.o -MD -MP -MF .deps/cmdline.Tpo -c -o cmdline.o /c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump/cmdline.c
g++ -DHAVE_CONFIG_H -I. -I/c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump -I..  -I../inc '-DCMDLINE_PARSER_PACKAGE="ofxdump"' -I/c/gcdev64/msys2/mingw32/include -I/usr/include  -DIN_LIBOFX -g -O2 -MT ofxdump.o -MD -MP -MF .deps/ofxdump.Tpo -c -o ofxdump.o /c/gcdev64/gnucash/master/src/libofx-0.10.2/ofxdump/ofxdump.cpp
mv -f .deps/cmdline.Tpo .deps/cmdline.Po
mv -f .deps/cmdline.Tpo .deps/cmdline.Po
mv: cannot stat '.deps/cmdline.Tpo': No such file or directory
make[3]: *** [Makefile:710: cmdline.o] Error 1
make[3]: *** Waiting for unfinished jobs....
mv -f .deps/ofxdump.Tpo .deps/ofxdump.Po
mv -f .deps/ofxdump.Tpo .deps/ofxdump.Po
/bin/sh ../libtool  --tag=CXX   --mode=link g++  -DIN_LIBOFX -g -O2  -L/c/gcdev64/gnucash/master/inst/lib -L/c/gcdev64/msys2/mingw32/lib -L/usr/lib -o ofxdump.exe cmdline.o ofxdump.o ../lib/libofx.la
mv: cannot stat '.deps/ofxdump.Tpo': No such file or directory
make[3]: *** [Makefile:731: ofxdump.o] Error 1
make[3]: Leaving directory '/c/gcdev64/gnucash/master/build/libofx-0.10.2/ofxdump'
```

This PR makes the manpage targets depend on the executable instead.

A second commit applies the `HAVE_HELP2MAN` and `HELP2MAN` configure variables to `ofxconnect.1`, matching `ofxdump.1`.