### PR TITLE
Don't deconst iconv input buffer under Windows

### DIFF
--- a/lib/ofx_preproc.cpp
+++ b/lib/ofx_preproc.cpp
@@ -308,8 +308,12 @@ int ofx_proc_file(LibofxContextPtr ctx, const char * p_filename)
             const char* inchar = s_buffer.c_str();
             char * outchar = iconv_buffer;
             int iconv_retval = iconv (conversion_descriptor,
-                                      const_cast<char**>(&inchar), &inbytesleft,
-                                      &outchar, &outbytesleft);
+#ifdef _WIN32 //Win32's iconv implementation takes a const char** inchar
+                                      &inchar,
+#else
+                                      const_cast<char**>(&inchar),
+#endif
+                                      &inbytesleft, &outchar, &outbytesleft);
             if (iconv_retval == -1)
             {
               message_out(ERROR, "ofx_proc_file(): Iconv conversion error");


### PR DESCRIPTION
Fixes #51