### PR TITLE
Minor code cleanup in CharStringtostring function and its header

### DIFF
--- a/lib/ofc_sgml.cpp
+++ b/lib/ofc_sgml.cpp
@@ -63,8 +63,7 @@ public:
   */
   void startElement (const StartElementEvent & event)
   {
-    std::string identifier;
-    CharStringtostring (event.gi, identifier);
+    std::string identifier = CharStringtostring (event.gi);
     message_out(PARSER, "startElement event received from OpenSP for element " + identifier);
 
     position = event.pos;
@@ -208,11 +207,8 @@ public:
   */
   void endElement (const EndElementEvent & event)
   {
-    std::string identifier;
-    bool end_element_for_data_element;
-
-    CharStringtostring (event.gi, identifier);
-    end_element_for_data_element = is_data_element;
+    std::string identifier = CharStringtostring (event.gi);
+    bool end_element_for_data_element = is_data_element;
     message_out(PARSER, "endElement event received from OpenSP for element " + identifier);
 
     position = event.pos;
@@ -293,7 +289,6 @@ public:
   void error (const ErrorEvent & event)
   {
     std::string message;
-    std::string string_buf;
     OfxMsgType error_type = ERROR;
 
     position = event.pos;
@@ -327,7 +322,7 @@ public:
     default:
       message = message + "OpenSP sent an unknown error to LibOFX (You probably have a newer version of OpenSP):";
     }
-    message =	message + "\n" + CharStringtostring (event.message, string_buf);
+    message =	message + "\n" + CharStringtostring (event.message);
     message_out (error_type, message);
   }
 

--- a/lib/ofx_sgml.cpp
+++ b/lib/ofx_sgml.cpp
@@ -74,8 +74,7 @@ public:
   */
   void startElement (const StartElementEvent & event)
   {
-    std::string identifier;
-    CharStringtostring (event.gi, identifier);
+    std::string identifier = CharStringtostring (event.gi);
     message_out(PARSER, "startElement event received from OpenSP for element " + identifier);
 
     position = event.pos;
@@ -270,11 +269,8 @@ public:
   */
   void endElement (const EndElementEvent & event)
   {
-    std::string identifier;
-    bool end_element_for_data_element;
-
-    CharStringtostring (event.gi, identifier);
-    end_element_for_data_element = is_data_element;
+    std::string identifier = CharStringtostring (event.gi);
+    bool end_element_for_data_element = is_data_element;
     message_out(PARSER, "endElement event received from OpenSP for element " + identifier);
 
     position = event.pos;
@@ -379,9 +375,8 @@ public:
   void error (const ErrorEvent & event)
   {
     std::string message;
-    std::string string_buf;
     OfxMsgType error_type = ERROR;
-    const std::string eventMessage = CharStringtostring (event.message, string_buf);
+    const std::string eventMessage = CharStringtostring (event.message);
 
     position = event.pos;
     message = message + "OpenSP parser: ";

--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -80,14 +80,10 @@ std::string CharStringtostring(const SGMLApplication::CharString source)
   return result;
 }
 
-std::string AppendCharStringtostring(const SGMLApplication::CharString source, std::string &dest)
+void AppendCharStringtostring(const SGMLApplication::CharString source, std::string &dest)
 {
-  size_t i;
-  for (i = 0; i < source.len; i++)
-  {
-    dest += (char)(((source.ptr)[i]));
-  }
-  return dest;
+  const std::string toBeAppended = CharStringtostring(source);
+  dest.append(toBeAppended);
 }
 
 /**

--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -37,37 +37,6 @@
 #endif
 
 
-/**
-   Convert an OpenSP CharString directly to a C++ stream, to enable the use of cout directly for debugging.
-*/
-/*ostream &operator<<(ostream &os, SGMLApplication::CharString s)
-  {
-  for (size_t i = 0; i < s.len; i++)
-  {
-  os << ((char *)(s.ptr))[i*sizeof(SGMLApplication::Char)];
-  }
-  return os;
-  }*/
-
-/*wostream &operator<<(wostream &os, SGMLApplication::CharString s)
-  {
-  for (size_t i = 0; i < s.len; i++)
-  {//cout<<i;
-  os << wchar_t(s.ptr[i*MULTIPLY4]);
-  }
-  return os;
-  }            */
-
-/*wchar_t* CharStringtowchar_t(SGMLApplication::CharString source, wchar_t *dest)
-  {
-  size_t i;
-  for (i = 0; i < source.len; i++)
-  {
-  dest[i]+=wchar_t(source.ptr[i*sizeof(SGMLApplication::Char)*(sizeof(char)/sizeof(wchar_t))]);
-  }
-  return dest;
-  }*/
-
 std::string CharStringtostring(const SGMLApplication::CharString source)
 {
   // The CharString type might have multi-byte characters if SP_MULTI_BYTE was defined

--- a/lib/ofx_utilities.cpp
+++ b/lib/ofx_utilities.cpp
@@ -68,17 +68,16 @@
   return dest;
   }*/
 
-std::string CharStringtostring(const SGMLApplication::CharString source, std::string &dest)
+std::string CharStringtostring(const SGMLApplication::CharString source)
 {
-  size_t i;
-  dest.assign("");//Empty the provided string
-  //  cout<<"Length: "<<source.len<<"sizeof(Char)"<<sizeof(SGMLApplication::Char)<<endl;
-  for (i = 0; i < source.len; i++)
+  // The CharString type might have multi-byte characters if SP_MULTI_BYTE was defined
+  std::string result;
+  result.resize(source.len);
+  for (size_t i = 0; i < source.len; i++)
   {
-    dest += (char)(((source.ptr)[i]));
-    //    cout<<i<<" "<<(char)(((source.ptr)[i]))<<endl;
+    result[i] = static_cast<char>(source.ptr[i]);
   }
-  return dest;
+  return result;
 }
 
 std::string AppendCharStringtostring(const SGMLApplication::CharString source, std::string &dest)

--- a/lib/ofx_utilities.hh
+++ b/lib/ofx_utilities.hh
@@ -58,7 +58,7 @@ std::ostream &operator<<(std::ostream &os, SGMLApplication::CharString s);
 wchar_t* CharStringtowchar_t(SGMLApplication::CharString source, wchar_t *dest);
 
 ///Convert OpenSP CharString to a C++ STL string
-std::string CharStringtostring(const SGMLApplication::CharString source, std::string &dest);
+std::string CharStringtostring(const SGMLApplication::CharString source);
 
 ///Append an OpenSP CharString to an existing C++ STL string
 std::string AppendCharStringtostring(const SGMLApplication::CharString source, std::string &dest);

--- a/lib/ofx_utilities.hh
+++ b/lib/ofx_utilities.hh
@@ -61,7 +61,7 @@ wchar_t* CharStringtowchar_t(SGMLApplication::CharString source, wchar_t *dest);
 std::string CharStringtostring(const SGMLApplication::CharString source);
 
 ///Append an OpenSP CharString to an existing C++ STL string
-std::string AppendCharStringtostring(const SGMLApplication::CharString source, std::string &dest);
+void AppendCharStringtostring(const SGMLApplication::CharString source, std::string &dest);
 
 ///Convert a C++ string containing a time in OFX format to a C time_t
 time_t ofxdate_to_time_t(const std::string& ofxdate);

--- a/lib/ofx_utilities.hh
+++ b/lib/ofx_utilities.hh
@@ -51,12 +51,6 @@ void STRNCPY(T& dest, const std::string& src)
  */
 #define ASSIGN_STRNCPY(DEST, VALUE) STRNCPY(DEST, VALUE); DEST ## _valid = true
 
-///Convert OpenSP CharString to a C++ stream
-std::ostream &operator<<(std::ostream &os, SGMLApplication::CharString s);
-
-///Convert OpenSP CharString and put it in the C wchar_t string provided
-wchar_t* CharStringtowchar_t(SGMLApplication::CharString source, wchar_t *dest);
-
 ///Convert OpenSP CharString to a C++ STL string
 std::string CharStringtostring(const SGMLApplication::CharString source);
 


### PR DESCRIPTION
Three minor code cleanup changes:

- Replace weird CharStringtostring signature by more expected one, because the previous code was not using the fact that the CharString could be taken as a simple "const char*" pointer, except that the "unsigned char" is a bit annoying.
- Remove unexpected (and unused) return value of AppendString... function
- Remove unused/commented-out code