### PR TITLE
Fix MSVC extern issues

### DIFF
--- a/ofx2qif/ofx2qif.c
+++ b/ofx2qif/ofx2qif.c
@@ -45,6 +45,13 @@
 
 #define QIF_FILE_MAX_SIZE 256000
 
+int ofx_PARSER_msg = false;
+int ofx_DEBUG_msg = false;
+int ofx_WARNING_msg = false;
+int ofx_ERROR_msg = false;
+int ofx_INFO_msg = false;
+int ofx_STATUS_msg = false;
+
 int ofx_proc_transaction_cb(const struct OfxTransactionData data, void * transaction_data)
 {
   char dest_string[255];
@@ -201,13 +208,6 @@ int ofx_proc_account_cb(const struct OfxAccountData data, void * account_data)
 
 int main (int argc, char *argv[])
 {
- ofx_PARSER_msg = false;
- ofx_DEBUG_msg = false;
- ofx_WARNING_msg = false;
- ofx_ERROR_msg = false;
- ofx_INFO_msg = false;
- ofx_STATUS_msg = false;
-
  LibofxContextPtr libofx_context = libofx_get_new_context();
  ofx_set_statement_cb(libofx_context, ofx_proc_statement_cb, 0);
  ofx_set_account_cb(libofx_context, ofx_proc_account_cb, 0);

--- a/ofxdump/ofxdump.cpp
+++ b/ofxdump/ofxdump.cpp
@@ -38,6 +38,12 @@
 
 #include "cmdline.h" /* Gengetopt generated parser */
 
+int ofx_PARSER_msg = false;
+int ofx_DEBUG_msg = false;
+int ofx_WARNING_msg = false;
+int ofx_ERROR_msg = false;
+int ofx_INFO_msg = false;
+int ofx_STATUS_msg = false;
 
 int ofx_proc_security_cb(struct OfxSecurityData data, void * security_data)
 {


### PR DESCRIPTION
When building the library dynamically with #63, MSVC complains about unresolved external symbols:
```
[build] ofxdump.obj : error LNK2001: unresolved external symbol ofx_PARSER_msg [C:\Users\User\source\repos\libofx\build\ofxdump\ofxdump.vcxproj]
[build] ofxdump.obj : error LNK2001: unresolved external symbol ofx_DEBUG_msg [C:\Users\User\source\repos\libofx\build\ofxdump\ofxdump.vcxproj]
[build] ofxdump.obj : error LNK2001: unresolved external symbol ofx_STATUS_msg [C:\Users\User\source\repos\libofx\build\ofxdump\ofxdump.vcxproj]
[build] ofxdump.obj : error LNK2001: unresolved external symbol ofx_INFO_msg [C:\Users\User\source\repos\libofx\build\ofxdump\ofxdump.vcxproj]
[build] ofxdump.obj : error LNK2001: unresolved external symbol ofx_WARNING_msg [C:\Users\User\source\repos\libofx\build\ofxdump\ofxdump.vcxproj]
[build] ofxdump.obj : error LNK2001: unresolved external symbol ofx_ERROR_msg [C:\Users\User\source\repos\libofx\build\ofxdump\ofxdump.vcxproj]
```

Per [MSVC docs](https://docs.microsoft.com/en-us/cpp/cpp/extern-cpp?view=msvc-170), `extern` should be defined *globally* in all of the files that do so, as opposed to within the scope of `main()` function.

This fixes the issue. 
