### PR TITLE
Initial support for exporting Config.cmake with targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(LIBOFX_VERSION_RELEASE_STRING ${LIBOFX_MAJOR_VERSION}.${LIBOFX_MINOR_VERSION
 # This is the library version (SONAME) so affects ABI
 # LIBOFX_LIBRARY_SONAME must be changed when ABI is broken (backwards compat)
 # LIBOFX_LIBRARY_VERSION must be changed if just adding new functions and such (backwards compat not broken)
+# Note that these are used by write_basic_package_version_file() to generate LibOFXConfigVersion.cmake
 set(LIBOFX_LIBRARY_SONAME 7)
 set(LIBOFX_LIBRARY_VERSION ${LIBOFX_LIBRARY_SONAME}.0.2)
 
@@ -139,22 +140,11 @@ if (MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif ()
 
-# TODO: once Autotools build stuff is gone, remove these and set them directly in libofx.pc.in itself
-set(OPENSPLIBS ${OpenSP_LIBRARIES})
-set(OPENSPINCLUDES ${OpenSP_INCLUDE_DIRS})
-set(VERSION ${LIBOFX_VERSION_RELEASE_STRING})
-set(prefix "${CMAKE_INSTALL_PREFIX}")
-set(exec_prefix "\${prefix}")
-set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
-set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-
 # create the libofx.h file out of the libofx.h.in
 configure_file("inc/libofx.h.in" "${CMAKE_CURRENT_BINARY_DIR}/inc/libofx.h")
 
 # create the config.h file out of the config.h.cmake
 configure_file("config.h.cmake" "${CMAKE_CURRENT_BINARY_DIR}/config.h")
-
-set(COMMON_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR}/inc ${CMAKE_CURRENT_BINARY_DIR})
 
 # Handle the getopt in a cross-platform way
 add_subdirectory(getopt)
@@ -198,12 +188,41 @@ elseif (DEFINED CMAKE_TOOLCHAIN_FILE)
     endif ()
 endif ()
 
+# TODO: once Autotools build stuff is gone, remove these and set them directly in libofx.pc.in itself
+set(OPENSPLIBS ${OpenSP_LIBRARIES})
+set(OPENSPINCLUDES ${OpenSP_INCLUDE_DIRS})
+set(VERSION ${LIBOFX_VERSION_RELEASE_STRING})
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+
 # create the libofx.pc pkg-config file out of the libofx.pc.in
 configure_file("libofx.pc.in" "${CMAKE_BINARY_DIR}/libofx.pc")
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(LibOFXConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/LibOFXConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libofx
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_BINDIR CMAKE_INSTALL_DATADIR
+        )
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/LibOFXConfigVersion.cmake
+        VERSION ${LIBOFX_LIBRARY_VERSION}
+        COMPATIBILITY SameMajorVersion
+        )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/LibOFXConfig.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/LibOFXConfigVersion.cmake
+            ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/FindOpenSP.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libofx
+        )
 
 install(DIRECTORY dtd DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/libofx FILES_MATCHING PATTERN "*.dtd" PATTERN "*.dcl")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/inc/libofx.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libofx)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libofx.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(EXPORT LibOFXTargets
+        FILE LibOFXTargets.cmake
+        NAMESPACE libofx::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libofx
+        )
 
 feature_summary(WHAT REQUIRED_PACKAGES_NOT_FOUND
         DESCRIPTION "The following REQUIRED packages have not been found:")

--- a/LibOFXConfig.cmake.in
+++ b/LibOFXConfig.cmake.in
@@ -1,0 +1,39 @@
+# LibOFXConfig.cmake provides information about the installed LibOFX library.
+# It can be used directly from CMake via find_package(libofx NO_MODULE)
+#
+# The following CMake variables are provided:
+#   LibOFX_INCLUDE_DIR            - the include directory
+#   LibOFX_LIBDIR                 - the library directory
+#   LibOFX_DATADIR                - the data dir, contains the .dtd/.dcl files
+#
+# The following imported library targets are created, which may be used directly
+# with target_link_libraries():
+#   libofx::libofx                - the LibOFX library
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/LibOFXTargets.cmake")
+
+include(CMakeFindDependencyMacro)
+
+if (${CMAKE_VERSION} VERSION_LESS 3.25.0)
+    set("${CMAKE_FIND_PACKAGE_NAME}_CMAKE_MODULE_PATH_save" "${CMAKE_MODULE_PATH}")
+    list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}")
+
+    find_dependency(OpenSP)
+
+    set(CMAKE_MODULE_PATH "${${CMAKE_FIND_PACKAGE_NAME}_CMAKE_MODULE_PATH_save}")
+    unset("${CMAKE_FIND_PACKAGE_NAME}_CMAKE_MODULE_PATH_save")
+else()
+    find_dependency(OpenSP)
+endif()
+
+if(@ENABLE_ICONV@)
+    find_dependency(Iconv)
+endif()
+
+set_and_check(LibOFX_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set_and_check(LibOFX_LIBDIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
+set_and_check(LibOFX_DATADIR "@PACKAGE_CMAKE_INSTALL_DATADIR@")
+
+check_required_components(LibOFX)

--- a/README
+++ b/README
@@ -149,8 +149,10 @@ LibOFX is based on the excellent OpenSP library written by James Clark, and now 
 | 1.5pre8                                             | COMPATIBLE with LibOFX >= 0.23 ||
 | 1.5                                                 | COMPATIBLE with LibOFX >= 0.23 ||
 
-### Locating the library file
+### Locating the OpenSP library file
 The [`FindOpenSP.cmake`](cmake/modules/FindOpenSP.cmake) module attempts to locate the library and its headers on the filesystem. If it fails to do so, or if you want to tell it to use a specific library file instead, you can pass [CMake switches](#cmake-switches) to do so.
+
+Note that the [upstream CMake](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindOpenSP.cmake) ships the [`FindOpenSP.cmake`](cmake/modules/FindOpenSP.cmake) module as of version 3.25, so its copy included with LibOFX sourcecode is used only if your CMake version is older than that.
 
 ### On the SP_MULTI_BYTE
 LibOFX must know if OpenSP library was compiled with the `SP_MULTI_BYTE` defined. The `FindOpenSP` module will attempt to detect the `SP_MULTI_BYTE`, based on OpenSP's `config.h`.  If, however, you see strings such as `SAEET` or `SAEET▄ù≡ù` instead of `STATEMENT` in ofxdump's output, it means that the library was misconfigured.
@@ -218,6 +220,15 @@ or `./configure` (for a distributed tarball)\
 2. `make`\
 And as root type:
 3. `make install`
+
+# Consuming (using as a dependency in your project)
+
+LibOFX is distributed with both PkgConfig libofx.pc (materialized from [libofx.pc.in](libofx.pc.in)) and [CMake config-file package](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html) (materialized from [LibOFXConfig.cmake.in](LibOFXConfig.cmake.in)). If possible, use the latter, as it is more robust
+and can automatically locate the OpenSP dependency library via the [`FindOpenSP.cmake`](#locating-the-opensp-library-file).
+
+A copy of [`FindOpenSP.cmake`](#locating-the-opensp-library-file) module is distributed alongside the CMake config-file package for use in case your CMake version does not ship it. See a note in
+[`FindOpenSP.cmake`](#locating-the-opensp-library-file) for details on that.
+
 
 ## FAQ/Troubleshooting 
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,29 +41,33 @@ if (WIN32)
     set(ofx_HEADERS ${ofx_HEADERS} win32.hh)
 endif ()
 
-add_library(ofx ${ofx_SRCS} ${ofx_HEADERS})
-set_target_properties(ofx PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
-set_target_properties(ofx PROPERTIES SOVERSION ${LIBOFX_LIBRARY_SONAME})
-set_target_properties(ofx PROPERTIES VERSION ${LIBOFX_LIBRARY_VERSION})
-target_link_libraries(ofx OpenSP::OpenSP)
-target_include_directories(ofx BEFORE PRIVATE ${COMMON_INCLUDE_DIRS})
-target_compile_definitions(ofx PRIVATE IN_LIBOFX=1 MAKEFILE_DTD_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/libofx/dtd/")
+add_library(libofx ${ofx_SRCS} ${ofx_HEADERS})
+set_target_properties(libofx PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
+set_target_properties(libofx PROPERTIES SOVERSION ${LIBOFX_LIBRARY_SONAME})
+set_target_properties(libofx PROPERTIES VERSION ${LIBOFX_LIBRARY_VERSION})
+set_target_properties(libofx PROPERTIES PREFIX "")
+
+target_link_libraries(libofx OpenSP::OpenSP)
+target_include_directories(libofx BEFORE
+        PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/inc> $<INSTALL_INTERFACE:include>
+        PRIVATE ${CMAKE_BINARY_DIR}
+)
+target_compile_definitions(libofx PRIVATE IN_LIBOFX=1 MAKEFILE_DTD_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/libofx/dtd/")
 
 if (CMAKE_COMPILER_IS_GNUCXX)
-    set_target_properties(ofx PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties(libofx PROPERTIES CXX_VISIBILITY_PRESET hidden)
 endif (CMAKE_COMPILER_IS_GNUCXX)
 
 if (MSVC)
-    set_target_properties(ofx PROPERTIES OUTPUT_NAME "libofx")
+    set_target_properties(libofx PROPERTIES OUTPUT_NAME "libofx")
 endif (MSVC)
 
 if (Iconv_FOUND)
-    target_link_libraries(ofx Iconv::Iconv)
+    target_link_libraries(libofx Iconv::Iconv)
 endif ()
 
-if (BUILD_SHARED_LIBS)
-  install(TARGETS ofx
-          LIBRARY
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  )
-endif ()
+install(TARGETS libofx
+        EXPORT LibOFXTargets
+        LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/ofx2qif/CMakeLists.txt
+++ b/ofx2qif/CMakeLists.txt
@@ -6,7 +6,6 @@ set(ofx2qif_SRCS
 )
 
 add_executable(ofx2qif ${ofx2qif_SRCS})
-target_link_libraries(ofx2qif ofx)
-target_include_directories(ofx2qif BEFORE PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(ofx2qif libofx)
 
 install(TARGETS ofx2qif RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/ofxconnect/CMakeLists.txt
+++ b/ofxconnect/CMakeLists.txt
@@ -14,8 +14,7 @@ if (CMAKE_CXX_STANDARD LESS 11)
 endif()
 
 add_executable(ofxconnect ${ofxconnect_SRCS})
-target_link_libraries(ofxconnect ofx CURL::libcurl PkgConfig::LIBXMLPP)
-target_include_directories(ofxconnect BEFORE PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(ofxconnect libofx CURL::libcurl PkgConfig::LIBXMLPP)
 target_compile_definitions(ofxconnect PRIVATE
         CMDLINE_PARSER_PACKAGE="ofxconnect"
         CMDLINE_PARSER_PACKAGE_NAME="ofxconnect"

--- a/ofxdump/CMakeLists.txt
+++ b/ofxdump/CMakeLists.txt
@@ -7,8 +7,7 @@ set(ofxdump_SRCS
 )
 
 add_executable(ofxdump ${ofxdump_SRCS})
-target_link_libraries(ofxdump ofx)
-target_include_directories(ofxdump BEFORE PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(ofxdump libofx)
 target_compile_definitions(ofxdump PRIVATE CMDLINE_PARSER_PACKAGE="ofxdump"
         CMDLINE_PARSER_PACKAGE_NAME="ofxdump"
         CMDLINE_PARSER_VERSION="${LIBOFX_VERSION_RELEASE_STRING}"


### PR DESCRIPTION
This adds support for exporting a LibOfxConfig.cmake file, together with LibOfxConfigVersion.cmake and LibOfxTargets.cmake.

Fixes #74