### PR TITLE
Add creation of source package to github action.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -36,3 +36,13 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by CMake configuration.
       run: ctest -C ${{env.BUILD_TYPE}}
+
+    - name: Create source package artifact
+      working-directory: ${{github.workspace}}/build
+      run: make package_source
+
+    - name: Upload source package artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: package_source
+        path: ${{github.workspace}}/build/libofx-*-Source.tar.gz


### PR DESCRIPTION
This PR adds creation of source package to github action and tries to put it online as artifact, but this way of upload seems quite pointless. Maybe rather go towards implementing a full release-on-tag-push action, which then creates both source and binary packages. Or are the auto-generated source packages of the releases already sufficient anyway? -> Edit: oh, indeed the auto-generated source package is apparently already sufficient!