### PR TITLE
Windows: Ensure to use the ascii version of function (#84)

### DIFF
--- a/lib/ofx_preproc.cpp
+++ b/lib/ofx_preproc.cpp
@@ -523,7 +523,7 @@ static std::string get_dtd_installation_directory()
   char ch_fn[MAX_PATH], *p;
   std::string str_fn;
 
-  if (!GetModuleFileName(NULL, ch_fn, MAX_PATH)) return "";
+  if (!GetModuleFileNameA(NULL, ch_fn, MAX_PATH)) return "";
 
   if ((p = strrchr(ch_fn, '\\')) != NULL)
     * p = '\0';


### PR DESCRIPTION
In the issue report, the windows headers call the wide-char version (`W`suffix) of that function instead of the ascii version (`A` suffix). Maybe the solution is to hard-code the fact that we want the ascii version? In any case the subsequent code is written only with ascii in mind. This will probably fail if the DTD path has non-ascii characters included, but this failure has been there all the way.