### PR TITLE
Define HAVE_LIBCURL when using Autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,8 @@ AM_CONDITIONAL(HAVE_HELP2MAN, test "x$HELP2MAN" != "xno")
 # ----------------------------------------------------------------------------
 
 PKG_CHECK_MODULES(LIBCURL, libcurl >= 7.9.7,
-        [libcurl_available=yes],
+        [libcurl_available=yes
+         AC_DEFINE(HAVE_LIBCURL, 1, [Defined if libcurl is available])],
         [libcurl_available=no
          AC_MSG_WARN([libcurl is not available. ofxconnect (Direct connect samples) will NOT be built.])
         ])

--- a/ofxconnect/ofxconnect.cpp
+++ b/ofxconnect/ofxconnect.cpp
@@ -86,7 +86,7 @@ bool post(const char* request, const char* url, const char* filename)
 #else
 bool post(const char*, const char*, const char*)
 {
-  std::cerr << "ERROR: libox must be configured with libcurl to post this request directly" << std::endl;
+  std::cerr << "ERROR: libofx must be configured with libcurl to post this request directly" << std::endl;
   return false;
 }
 #endif


### PR DESCRIPTION
Even if libcurl was available, the conditional code for `ofxconnect` that uses libcurl was not compiled, so that it was not possible to connect to an OFX server. Note that this currently affects Debian and Ubuntu, which build the libofx package using Autoconf.

Also, correct a misspelling of "libofx" in the error message that was returned instead.

Fixes: 1b9e698000a2 ("Remove hand-written libcurl configure check, use pkg-config instead.")