### PR TITLE
ofxdump: fix parallel build issue with man page generation

### DIFF
--- a/ofxconnect/Makefile.am
+++ b/ofxconnect/Makefile.am
@@ -11,13 +11,14 @@ AM_CPPFLAGS = \
 
 
 if USE_GENGETOPT 
-CLEANFILES = cmdline.c cmdline.h
 
 cmdline.c cmdline.h: cmdline.ggo Makefile
 	gengetopt --unamed-opts < $<
 
 endif
-MAINTAINERCLEANFILES  = cmdline.c cmdline.h
+
+CLEANFILES = cmdline.c cmdline.h ofxconnect.1
+MAINTAINERCLEANFILES  = cmdline.c cmdline.h ofxconnect.1
 
 EXTRA_DIST = cmdline.ggo test-privateserver.sh CMakeLists.txt
 
@@ -25,7 +26,7 @@ EXTRA_DIST = cmdline.ggo test-privateserver.sh CMakeLists.txt
 # the key needed to run this test.
 TESTS = test-privateserver.sh 
 
-ofxconnect.1: $(top_srcdir)/configure.ac
+ofxconnect.1: $(top_srcdir)/configure.ac ofxconnect
 if HAVE_HELP2MAN
 	$(HELP2MAN)  -n 'Create a statement request file' -N --output=ofxconnect.1 ./ofxconnect$(EXEEXT)
 else

--- a/ofxdump/Makefile.am
+++ b/ofxdump/Makefile.am
@@ -8,21 +8,21 @@ AM_CPPFLAGS = \
 	'-DCMDLINE_PARSER_PACKAGE="ofxdump"'
 
 if USE_GENGETOPT 
-CLEANFILES = cmdline.c cmdline.h
 
 cmdline.c cmdline.h: cmdline.ggo Makefile
 	gengetopt --unamed-opts < $<
 
 endif
 
-ofxdump.1: $(top_srcdir)/configure.ac
+ofxdump.1: $(top_srcdir)/configure.ac ofxdump
 if HAVE_HELP2MAN
 	$(HELP2MAN) -n 'Dump content of OFX files as human-readable text' -N --output=ofxdump.1 ./ofxdump$(EXEEXT)
 else
 	echo "*** No man page available because of missing help2man tool" > $@
 endif
 
-MAINTAINERCLEANFILES  = cmdline.c cmdline.h
+CLEANFILES = cmdline.c cmdline.h ofxdump.1
+MAINTAINERCLEANFILES  = cmdline.c cmdline.h ofxdump.1
 EXTRA_DIST = cmdline.ggo CMakeLists.txt
 
 # Run all our example files through ofxdump to verify we can parse


### PR DESCRIPTION
Fixes the following:
```
/usr/bin/help2man -n 'Dump content of OFX files as human-readable text' -N --output=ofxdump.1 ./ofxdump
help2man: can't get `--help' info from ./ofxdump
Try `--no-discard-stderr' if option outputs to stderr
make[2]: *** [Makefile:1253: ofxdump.1] Error 127
make[2]: Leaving directory '/var/tmp/portage/dev-libs/libofx-0.10.9-r1/work/libofx-0.10.9/ofxdump'
make[1]: *** [Makefile:551: all-recursive] Error 1
```

We need to make sure that ofxdump has been built before trying to run help2man which will execute it.